### PR TITLE
can search posts blogs and authors at the same time by tag

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -193,13 +193,10 @@ namespace TabloidCLI
                             Author = new Author
                             {
                                 Id = reader.GetInt32(reader.GetOrdinal("AuthorId")),
-                                //FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
-                                //LastName = reader.GetString(reader.GetOrdinal("LastName"))
                             },
                             Blog = new Blog
                             {
                                 Id = reader.GetInt32(reader.GetOrdinal("BlogId")),
-                                //Title = reader.GetString(reader.GetOrdinal("BlogTitle"))
                             }
                         };
                         results.Add(post);

--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -37,6 +37,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     SearchPosts();
                     return this;
                 case "4":
+                    SearchAll();
                     return this;
                 case "0":
                     return _parentUI;
@@ -96,5 +97,45 @@ namespace TabloidCLI.UserInterfaceManagers
                 results.Display();
             }
         }
+
+        private void SearchAll()
+        {
+            Console.Write("Tag> ");
+            string tagName = Console.ReadLine();
+            SearchResults<Blog> blogResults = _tagRepository.SearchBlogs(tagName);
+            SearchResults<Author> authorResults = _tagRepository.SearchAuthors(tagName);
+            SearchResults<Post> postResults = _tagRepository.SearchPosts(tagName);
+            if (blogResults.NoResultsFound)
+            {
+                Console.WriteLine("Blog:");
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                Console.WriteLine("Blogs:");
+                blogResults.Display();
+            }
+            if (authorResults.NoResultsFound)
+            {
+                Console.WriteLine("Author:");
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                Console.WriteLine("Authors:");
+                authorResults.Display();
+            }
+            if (postResults.NoResultsFound)
+            {
+                Console.WriteLine("Post:");
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                Console.WriteLine("Posts:");
+                postResults.Display();
+            }
+        }
     }
+    
 }


### PR DESCRIPTION
#### Changes Made
1. Modified file `SearchManager.cs`  to include `Search all (posts, authors, blogs)` by tag.
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout DS_ticket5_searchall
    ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
    when the user selects the search all option the program searchs ALL blogs posts and authors for the specified tag and returns a list of each containing that tag 
4. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.
